### PR TITLE
fix secondary axis visibility issue

### DIFF
--- a/ALLFED.mplstyle
+++ b/ALLFED.mplstyle
@@ -21,13 +21,9 @@ boxplot.meanprops.color:         3A913F
 text.color : dimgrey
 
 # AXES
-axes.edgecolor : (0.1,0.1,0.1) #Normalized RGB colours (from 0 to 1 instead of 0 to 255)
+axes.edgecolor : ffffff
 axes.labelcolor : dimgrey
 axes.linewidth : 1
-axes.spines.top : False
-axes.spines.right : False
-axes.spines.bottom : False
-axes.spines.left : False
 axes.axisbelow:True
 
 # GRID


### PR DESCRIPTION
When running this example code:
(adapted from https://matplotlib.org/stable/gallery/subplots_axes_and_figures/secondary_axis.html)

```
import matplotlib.pyplot as plt
import numpy as np
plt.style.use(
    "https://raw.githubusercontent.com/allfed/ALLFED-matplotlib-style-sheet/main/ALLFED.mplstyle"
)
fig, ax = plt.subplots(layout="constrained")
x = np.arange(0, 360, 1)
y = np.sin(2 * x * np.pi / 180)
ax.plot(x, y)
ax.set_xlabel("angle [degrees]")
ax.set_ylabel("signal")
ax.set_title("Sine wave")
def deg2rad(x):
    return x * np.pi / 180
def rad2deg(x):
    return x * 180 / np.pi
secax = ax.secondary_xaxis("top", functions=(deg2rad, rad2deg))
secax.set_xlabel("angle [rad]")
plt.show()
```

the secondary axis becomes visible despite "axes.spines.(...): False" in the template.
![image](https://github.com/user-attachments/assets/5f5b141c-8cf4-430b-9dea-4b6aa4d17057)

I think a quick an easy fix is to forgo the "axes.spines" settings and simply set the axes colour to white:
![Figure_1](https://github.com/user-attachments/assets/ed5d66c9-7173-4aef-8e49-d4ade83a577f)
